### PR TITLE
[Draft]: Initial changes to Support graceful node decommission

### DIFF
--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionAction.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.get;
+
+import org.opensearch.action.ActionType;
+
+public class GetDecommissionAction extends ActionType<GetDecommissionResponse> {
+
+    public static final GetDecommissionAction INSTANCE = new GetDecommissionAction();
+    public static final String NAME = "cluster:admin/management/decommission/get";
+
+    private GetDecommissionAction() {
+        super(NAME, GetDecommissionResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionRequest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.get;
+
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadRequest;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Get Decommissioned attribute request
+ *
+ * @opensearch.internal
+ */
+public class GetDecommissionRequest extends ClusterManagerNodeReadRequest<GetDecommissionRequest> {
+
+    public GetDecommissionRequest() {
+    }
+
+    public GetDecommissionRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionRequestBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.get;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesRequestBuilder;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.opensearch.action.support.clustermanager.ClusterManagerNodeReadOperationRequestBuilder;
+import org.opensearch.client.OpenSearchClient;
+
+public class GetDecommissionRequestBuilder extends ClusterManagerNodeReadOperationRequestBuilder<
+    GetDecommissionRequest,
+    GetDecommissionResponse,
+    GetDecommissionRequestBuilder> {
+
+    // TODO - Support for get attribute with the name?
+
+    /**
+     * Creates new get decommissioned attributes request builder
+     */
+    public GetDecommissionRequestBuilder(OpenSearchClient client, GetDecommissionAction action) {
+        super(client, action, new GetDecommissionRequest());
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/GetDecommissionResponse.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.get;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.cluster.metadata.DecommissionedAttributeMetadata;
+import org.opensearch.cluster.metadata.DecommissionedAttributesMetadata;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.opensearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+public class GetDecommissionResponse extends ActionResponse implements ToXContentObject {
+
+    private DecommissionedAttributesMetadata decommissionedAttributes;
+
+    GetDecommissionResponse(DecommissionedAttributesMetadata decommissionedAttributes) {
+        this.decommissionedAttributes = decommissionedAttributes;
+    }
+
+    GetDecommissionResponse(StreamInput in) throws IOException {
+        decommissionedAttributes = new DecommissionedAttributesMetadata(in);
+    }
+
+    /**
+     * List of decommissioned attributes to return
+     *
+     * @return list of decommissioned attributes
+     */
+    public List<DecommissionedAttributeMetadata> decommissionedAttributes(){
+        return decommissionedAttributes.decommissionedAttributes();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        decommissionedAttributes.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        decommissionedAttributes.toXContent(
+            builder,
+            null //TODO - check for params here if any
+        );
+        builder.endObject();
+        return builder;
+    }
+
+    public static GetDecommissionResponse fromXContent(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        return new GetDecommissionResponse(DecommissionedAttributesMetadata.fromXContent(parser));
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/TransportGetDecommissionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/get/TransportGetDecommissionAction.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.get;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeReadAction;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.metadata.DecommissionedAttributesMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Objects;
+
+public class TransportGetDecommissionAction extends TransportClusterManagerNodeReadAction<
+    GetDecommissionRequest,
+    GetDecommissionResponse> {
+
+    @Inject
+    public TransportGetDecommissionAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver
+    ) {
+        super(
+            GetDecommissionAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            GetDecommissionRequest::new,
+            indexNameExpressionResolver
+        );
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected GetDecommissionResponse read(StreamInput in) throws IOException {
+        return new GetDecommissionResponse(in);
+    }
+
+    @Override
+    protected void masterOperation(
+        GetDecommissionRequest request,
+        ClusterState state,
+        ActionListener<GetDecommissionResponse> listener
+    ) throws Exception {
+        Metadata metadata = state.metadata();
+        DecommissionedAttributesMetadata decommissionedAttributes = metadata.custom(DecommissionedAttributesMetadata.TYPE);
+        listener.onResponse(
+            new GetDecommissionResponse(
+                Objects.requireNonNullElseGet(decommissionedAttributes,
+                    () -> new DecommissionedAttributesMetadata(Collections.emptyList())
+                )
+            )
+        );
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(GetDecommissionRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionAction.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.put;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Transport endpoint for adding exclusions to voting config
+ *
+ * @opensearch.internal
+ */
+public final class PutDecommissionAction extends ActionType<PutDecommissionResponse> {
+    public static final PutDecommissionAction INSTANCE = new PutDecommissionAction();
+    public static final String NAME = "cluster:admin/management/decommission/put";
+
+    private PutDecommissionAction() {
+        super(NAME, PutDecommissionResponse::new);
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionRequest.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionRequest.java
@@ -1,0 +1,167 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.put;
+
+import org.opensearch.OpenSearchGenerationException;
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.master.AcknowledgedRequest;
+import org.opensearch.cluster.decommission.DecommissionedAttribute;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.DeprecationHandler;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class PutDecommissionRequest extends AcknowledgedRequest<PutDecommissionRequest> {
+
+    private String name;
+    private DecommissionedAttribute decommissionedAttribute;
+    // TODO - What all request params needed? dry_run, timeout, master_timeout, retry_failed?
+
+    public PutDecommissionRequest() {
+    }
+
+    public PutDecommissionRequest(String name, DecommissionedAttribute decommissionedAttribute) {
+        this.name = name;
+        this.decommissionedAttribute = decommissionedAttribute;
+    }
+
+    public PutDecommissionRequest(StreamInput in) throws IOException {
+        super(in);
+        name = in.readString();
+        decommissionedAttribute = new DecommissionedAttribute(in);
+    }
+
+    /**
+     * Sets the decommission attribute name for decommission request
+     *
+     * @param name of the decommission attribute
+     * @return the current object
+     */
+    public PutDecommissionRequest setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * @return Returns the name of the decommission attribute
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Sets decommission attribute for decommission request
+     *
+     * @param decommissionedAttribute values that needs to be decommissioned
+     * @return the current object
+     */
+    public PutDecommissionRequest setDecommissionAttribute(DecommissionedAttribute decommissionedAttribute) {
+        this.decommissionedAttribute = decommissionedAttribute;
+        return this;
+    }
+
+    public PutDecommissionRequest setDecommissionAttribute(Map<String, Object> source) {
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.map(source);
+            return setDecommissionAttribute(BytesReference.bytes(builder), builder.contentType());
+        } catch (IOException e) {
+            throw new OpenSearchGenerationException("Failed to generate [" + source + "]", e);
+        }
+    }
+
+    public PutDecommissionRequest setDecommissionAttribute(BytesReference source, XContentType contentType) {
+        try (
+            XContentParser parser = XContentHelper.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                source,
+                contentType
+            )
+        ) {
+            XContentParser.Token token;
+            // move to the first alias
+            parser.nextToken();
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    String fieldName = parser.currentName();
+                    List<String> values = new ArrayList<>();
+                    token = parser.nextToken();
+                    if (token == XContentParser.Token.VALUE_STRING) {
+                        values.add(parser.text());
+                    } else if (token == XContentParser.Token.START_ARRAY) {
+                        while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                            if (token == XContentParser.Token.VALUE_STRING) {
+                                values.add(parser.text());
+                            } else {
+                                parser.skipChildren();
+                            }
+                        }
+                    } else throw new OpenSearchParseException("failed to parse attribute [{}], unknown type", fieldName);
+                    decommissionedAttribute = new DecommissionedAttribute(fieldName, values);
+                }
+            }
+            return this;
+        } catch (IOException e) {
+            throw new OpenSearchParseException("Failed to parse decommission attribute", e);
+        }
+    }
+
+    /**
+     * @return Returns the decommission attribute values
+     */
+    public DecommissionedAttribute getDecommissionAttribute() {
+        return this.decommissionedAttribute;
+    }
+
+    @SuppressWarnings("unchecked")
+    public PutDecommissionRequest source(Map<String, Object> source) {
+        for (Map.Entry<String, ?> entry : source.entrySet()) {
+            setName(entry.getKey());
+            if (!(entry.getValue() instanceof Map)) {
+                throw new OpenSearchParseException("key [decommissionedAttribute] must be an object");
+            }
+            setDecommissionAttribute((Map<String, Object>) entry.getValue());
+        }
+        return this;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        // TODO - Add request validators here
+        return null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(name);
+        decommissionedAttribute.writeTo(out);
+    }
+
+    @Override
+    public String toString() {
+        return "PutDecommissionRequest{" +
+            "name='" + name + '\'' +
+            ", decommissionedAttribute=" + decommissionedAttribute +
+            '}';
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionRequestBuilder.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionRequestBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.put;
+
+import org.opensearch.action.support.master.AcknowledgedRequestBuilder;
+import org.opensearch.client.OpenSearchClient;
+import org.opensearch.cluster.decommission.DecommissionedAttribute;
+
+/**
+ * Builder for a decommission request
+ *
+ * @opensearch.internal
+ */
+public class PutDecommissionRequestBuilder extends AcknowledgedRequestBuilder<
+    PutDecommissionRequest,
+    PutDecommissionResponse,
+    PutDecommissionRequestBuilder> {
+    public PutDecommissionRequestBuilder(OpenSearchClient client, PutDecommissionAction action) {
+        super(client, action, new PutDecommissionRequest());
+    }
+
+    /**
+     *
+     * @param name name of the attribute
+     * @return current object
+     */
+    public PutDecommissionRequestBuilder setName(String name) {
+        request.setName(name);
+        return this;
+    }
+
+    /**
+     * @param decommissionedAttribute decommission attribute
+     * @return current object
+     */
+    public PutDecommissionRequestBuilder setDecommissionedAttribute(DecommissionedAttribute decommissionedAttribute) {
+        request.setDecommissionAttribute(decommissionedAttribute);
+        return this;
+    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionResponse.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/PutDecommissionResponse.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.put;
+
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContentObject;
+
+import java.io.IOException;
+
+/**
+ * A response to {@link PutDecommissionRequest} indicating that requested nodes has been decommissioned
+ *
+ * @opensearch.internal
+ */
+public class PutDecommissionResponse extends AcknowledgedResponse implements ToXContentObject {
+
+    PutDecommissionResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    PutDecommissionResponse(boolean acknowledged) {
+        super(acknowledged);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+
+    // TODO - once we have custom fields, we need to override addCustomFields method
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/TransportPutDecommissionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/TransportPutDecommissionAction.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.action.admin.cluster.decommission.put;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
+import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsResponse;
+import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
+import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
+import org.opensearch.action.support.master.AcknowledgedResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.NotClusterManagerException;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.cluster.block.ClusterBlockLevel;
+import org.opensearch.cluster.coordination.NodeDecommissionedException;
+import org.opensearch.cluster.decommission.DecommissionService;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportPutDecommissionAction extends TransportClusterManagerNodeAction<
+    PutDecommissionRequest,
+    PutDecommissionResponse> {
+
+    private static final Logger logger = LogManager.getLogger(TransportPutDecommissionAction.class);
+
+    private final DecommissionService decommissionService;
+    private final TransportAddVotingConfigExclusionsAction exclusionsAction;
+
+    private volatile List<String> decommissionedNodesID;
+
+    @Inject
+    public TransportPutDecommissionAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        DecommissionService decommissionService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        TransportAddVotingConfigExclusionsAction exclusionsAction
+    ) {
+        super(
+            PutDecommissionAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            PutDecommissionRequest::new,
+            indexNameExpressionResolver
+        );
+        this.decommissionService = decommissionService;
+        this.exclusionsAction = exclusionsAction;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected PutDecommissionResponse read(StreamInput in) throws IOException {
+        return new PutDecommissionResponse(in);
+    }
+
+    @Override
+    protected void masterOperation(
+        PutDecommissionRequest request,
+        ClusterState state,
+        ActionListener<PutDecommissionResponse> listener) throws Exception {
+
+        boolean currentMasterDecommission = false;
+        DiscoveryNode masterNode = clusterService.state().getNodes().getMasterNode();
+        for (String decommissionedZone : request.getDecommissionAttribute().values()) {
+            if (masterNode.getAttributes().get(request.getDecommissionAttribute().key()).equals(decommissionedZone)) {
+                currentMasterDecommission = true;
+            }
+        }
+
+        if (currentMasterDecommission) {
+            logger.info("Current master in getting decommissioned. Will first abdicate master and then execute the decommission");
+            ActionListener<AddVotingConfigExclusionsResponse> addVotingConfigExclusionsListener = new ActionListener<>() {
+                @Override
+                public void onResponse(AddVotingConfigExclusionsResponse addVotingConfigExclusionsResponse) {
+                    logger.info("Master abdicated - Response received");
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            };
+            exclusionsAction.execute(new AddVotingConfigExclusionsRequest(masterNode.getName()), addVotingConfigExclusionsListener);
+            throw new NotClusterManagerException("abdicated");
+        }
+
+        decommissionService.registerDecommissionAttribute(
+            request,
+            ActionListener.delegateFailure(
+                listener,
+                (delegatedListener, response) -> delegatedListener.onResponse(new PutDecommissionResponse(response.isAcknowledged()))
+            )
+        );
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(PutDecommissionRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+
+
+//    private static List<DiscoveryNode> resolveDecommissionedNodes(
+//        PutDecommissionRequest request,
+//        ClusterState state
+//    ) {
+//        return getDecommissionedNodes(
+//            state
+//        );
+//    }
+//    List<DiscoveryNode> getDecommissionedNodes(ClusterState currentState) {
+//        final DiscoveryNodes currentNodes = currentState.nodes();
+//        List<DiscoveryNode> decommissionedNodes = new ArrayList<>();
+//        if (nodeIds.length >= 1) {
+//            for (String nodeId : nodeIds) {
+//                if (currentNodes.nodeExists(nodeId)) {
+//                    DiscoveryNode discoveryNode = currentNodes.get(nodeId);
+//                    decommissionedNodes.add(discoveryNode);
+//                }
+//            }
+//        } else {
+//            assert nodeNames.length >= 1;
+//            Map<String, DiscoveryNode> existingNodes = StreamSupport.stream(currentNodes.spliterator(), false)
+//                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity()));
+//
+//            for (String nodeName : nodeNames) {
+//                if (existingNodes.containsKey(nodeName)) {
+//                    DiscoveryNode discoveryNode = existingNodes.get(nodeName);
+//                    decommissionedNodes.add(discoveryNode);
+//                }
+//            }
+//        }
+//        return decommissionedNodes;
+//    }
+}

--- a/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/TransportPutDecommissionAction.java
+++ b/server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/TransportPutDecommissionAction.java
@@ -10,11 +10,21 @@ package org.opensearch.action.admin.cluster.decommission.put;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.ActionListenerResponseHandler;
+import org.opensearch.action.LatchedActionListener;
 import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.opensearch.action.admin.cluster.configuration.AddVotingConfigExclusionsResponse;
 import org.opensearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
+import org.opensearch.action.admin.cluster.node.stats.NodeStats;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsAction;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.opensearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.shards.IndicesShardStoresAction;
+import org.opensearch.action.admin.indices.shards.IndicesShardStoresRequest;
+import org.opensearch.action.admin.indices.shards.IndicesShardStoresResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.TransportClusterManagerNodeAction;
 import org.opensearch.action.support.master.AcknowledgedResponse;
@@ -24,17 +34,30 @@ import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.block.ClusterBlockLevel;
 import org.opensearch.cluster.coordination.NodeDecommissionedException;
 import org.opensearch.cluster.decommission.DecommissionService;
+import org.opensearch.cluster.decommission.DecommissionedAttribute;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.allocation.command.AbstractAllocateAllocationCommand;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Strings;
+import org.opensearch.common.collect.ImmutableOpenIntMap;
+import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.http.HttpStats;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TransportPutDecommissionAction extends TransportClusterManagerNodeAction<
     PutDecommissionRequest,
@@ -111,6 +134,10 @@ public class TransportPutDecommissionAction extends TransportClusterManagerNodeA
             throw new NotClusterManagerException("abdicated");
         }
 
+
+        List<DiscoveryNode> decommissionedNodes = getDecommissionedNodes(request.getDecommissionAttribute(), state);
+        checkHttpStatsForDecomissionedNodes(decommissionedNodes, listener);
+
         decommissionService.registerDecommissionAttribute(
             request,
             ActionListener.delegateFailure(
@@ -120,42 +147,102 @@ public class TransportPutDecommissionAction extends TransportClusterManagerNodeA
         );
     }
 
+    private void checkHttpStatsForDecomissionedNodes(List<DiscoveryNode> decommissionedNodes, ActionListener<PutDecommissionResponse> listener) {
+        ActionListener<NodesStatsResponse> nodesStatsResponseActionListener = new ActionListener<NodesStatsResponse>() {
+            @Override
+            public void onResponse(NodesStatsResponse nodesStatsResponse) {
+                boolean hasActiveConnections = false;
+                List<NodeStats> responseNodes = nodesStatsResponse.getNodes();
+                for (int i=0; i < responseNodes.size(); i++) {
+                    HttpStats httpStats = responseNodes.get(i).getHttp();
+                    if (httpStats != null && httpStats.getServerOpen() != 0) {
+                        hasActiveConnections = true;
+                        break;
+                    }
+                }
+                if (hasActiveConnections) {
+                    // Slow down the next call to get the Http stats from the decommissioned nodes.
+                    delay(1000L);
+                    // Check again for active connections. Repeat the process till we have no more active requests open.
+                    waitForGracefulDecommission(decommissionedNodes, this);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        };
+        waitForGracefulDecommission(decommissionedNodes, nodesStatsResponseActionListener);
+    }
+
+    private void delay(long delayMillis) {
+        try {
+            Thread.sleep(delayMillis);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+    }
+
+    private void waitForGracefulDecommission(List<DiscoveryNode> decommissionedNodes, ActionListener<NodesStatsResponse> listener) {
+
+        if(decommissionedNodes == null || decommissionedNodes.isEmpty()) {
+            return;
+        }
+        String[] nodes = decommissionedNodes.stream()
+            .map(DiscoveryNode::getId)
+            .toArray(String[]::new);
+
+        if (nodes.length == 0) {
+            return;
+        }
+
+        final NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(nodes);
+        nodesStatsRequest.clear();
+        nodesStatsRequest.addMetric(NodesStatsRequest.Metric.HTTP.metricName());
+
+        transportService.sendRequest(
+            transportService.getLocalNode(),
+            NodesStatsAction.NAME,
+            nodesStatsRequest,
+            new TransportResponseHandler<NodesStatsResponse>() {
+                @Override
+                public void handleResponse(NodesStatsResponse response) {
+                    listener.onResponse(response);
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    listener.onFailure(exp);
+                }
+
+                @Override
+                public String executor() {
+                    return ThreadPool.Names.SAME;
+                }
+
+                @Override
+                public NodesStatsResponse read(StreamInput in) throws IOException {
+                    return new NodesStatsResponse(in);
+                }
+            });
+    }
+
     @Override
     protected ClusterBlockException checkBlock(PutDecommissionRequest request, ClusterState state) {
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
 
-
-//    private static List<DiscoveryNode> resolveDecommissionedNodes(
-//        PutDecommissionRequest request,
-//        ClusterState state
-//    ) {
-//        return getDecommissionedNodes(
-//            state
-//        );
-//    }
-//    List<DiscoveryNode> getDecommissionedNodes(ClusterState currentState) {
-//        final DiscoveryNodes currentNodes = currentState.nodes();
-//        List<DiscoveryNode> decommissionedNodes = new ArrayList<>();
-//        if (nodeIds.length >= 1) {
-//            for (String nodeId : nodeIds) {
-//                if (currentNodes.nodeExists(nodeId)) {
-//                    DiscoveryNode discoveryNode = currentNodes.get(nodeId);
-//                    decommissionedNodes.add(discoveryNode);
-//                }
-//            }
-//        } else {
-//            assert nodeNames.length >= 1;
-//            Map<String, DiscoveryNode> existingNodes = StreamSupport.stream(currentNodes.spliterator(), false)
-//                .collect(Collectors.toMap(DiscoveryNode::getName, Function.identity()));
-//
-//            for (String nodeName : nodeNames) {
-//                if (existingNodes.containsKey(nodeName)) {
-//                    DiscoveryNode discoveryNode = existingNodes.get(nodeName);
-//                    decommissionedNodes.add(discoveryNode);
-//                }
-//            }
-//        }
-//        return decommissionedNodes;
-//    }
+    private List<DiscoveryNode> getDecommissionedNodes(DecommissionedAttribute decommissionedAttribute, ClusterState currentState) {
+        final DiscoveryNodes currentNodes = currentState.nodes();
+        List<DiscoveryNode> decommissionedNodes = new ArrayList<>();
+        currentNodes.forEach(node -> {
+            if (node.getAttributes().containsKey("zone")
+                && node.getAttributes().get("zone").equals(decommissionedAttribute.values().get(0))) {
+                    decommissionedNodes.add(node);
+            }
+        });
+        return decommissionedNodes;
+    }
 }

--- a/server/src/main/java/org/opensearch/client/Requests.java
+++ b/server/src/main/java/org/opensearch/client/Requests.java
@@ -32,6 +32,8 @@
 
 package org.opensearch.client;
 
+import org.opensearch.action.admin.cluster.decommission.get.GetDecommissionRequest;
+import org.opensearch.action.admin.cluster.decommission.put.PutDecommissionRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.opensearch.action.admin.cluster.node.stats.NodesStatsRequest;
@@ -547,5 +549,17 @@ public class Requests {
      */
     public static SnapshotsStatusRequest snapshotsStatusRequest(String repository) {
         return new SnapshotsStatusRequest(repository);
+    }
+
+
+    /**
+     * Creates a new decommission request.
+     */
+    public static PutDecommissionRequest putDecommissionRequest() {
+        return new PutDecommissionRequest();
+    }
+
+    public static GetDecommissionRequest getDecommissionRequest() {
+        return new GetDecommissionRequest();
     }
 }

--- a/server/src/main/java/org/opensearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/opensearch/cluster/ClusterModule.java
@@ -35,19 +35,7 @@ package org.opensearch.cluster;
 import org.opensearch.cluster.action.index.MappingUpdatedAction;
 import org.opensearch.cluster.action.index.NodeMappingRefreshAction;
 import org.opensearch.cluster.action.shard.ShardStateAction;
-import org.opensearch.cluster.metadata.ComponentTemplateMetadata;
-import org.opensearch.cluster.metadata.ComposableIndexTemplateMetadata;
-import org.opensearch.cluster.metadata.DataStreamMetadata;
-import org.opensearch.cluster.metadata.IndexGraveyard;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
-import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.cluster.metadata.MetadataDeleteIndexService;
-import org.opensearch.cluster.metadata.MetadataIndexAliasesService;
-import org.opensearch.cluster.metadata.MetadataIndexStateService;
-import org.opensearch.cluster.metadata.MetadataIndexTemplateService;
-import org.opensearch.cluster.metadata.MetadataMappingService;
-import org.opensearch.cluster.metadata.MetadataUpdateSettingsService;
-import org.opensearch.cluster.metadata.RepositoriesMetadata;
+import org.opensearch.cluster.metadata.*;
 import org.opensearch.cluster.routing.DelayedAllocationService;
 import org.opensearch.cluster.routing.allocation.AllocationService;
 import org.opensearch.cluster.routing.allocation.ExistingShardsAllocator;
@@ -190,6 +178,10 @@ public class ClusterModule extends AbstractModule {
             ComposableIndexTemplateMetadata::readDiffFrom
         );
         registerMetadataCustom(entries, DataStreamMetadata.TYPE, DataStreamMetadata::new, DataStreamMetadata::readDiffFrom);
+        registerMetadataCustom(entries,
+            DecommissionedAttributesMetadata.TYPE,
+            DecommissionedAttributesMetadata::new,
+            DecommissionedAttributesMetadata::readDiffFrom);
         // Task Status (not Diffable)
         entries.add(new Entry(Task.Status.class, PersistentTasksNodeService.Status.NAME, PersistentTasksNodeService.Status::new));
         return entries;
@@ -271,6 +263,13 @@ public class ClusterModule extends AbstractModule {
                 Metadata.Custom.class,
                 new ParseField(DataStreamMetadata.TYPE),
                 DataStreamMetadata::fromXContent
+            )
+        );
+        entries.add(
+            new NamedXContentRegistry.Entry(
+                Metadata.Custom.class,
+                new ParseField(DecommissionedAttributesMetadata.TYPE),
+                DecommissionedAttributesMetadata::fromXContent
             )
         );
         return entries;

--- a/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/JoinTaskExecutor.java
@@ -39,6 +39,8 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateTaskExecutor;
 import org.opensearch.cluster.NotClusterManagerException;
 import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.cluster.metadata.DecommissionedAttributeMetadata;
+import org.opensearch.cluster.metadata.DecommissionedAttributesMetadata;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -464,6 +466,20 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         }
     }
 
+    public static void ensureNodeNotDecommissioned(DiscoveryNode node, Metadata metadata) {
+        DecommissionedAttributesMetadata decommissionedAttributesMetadata = metadata.custom(DecommissionedAttributesMetadata.TYPE);
+        if (decommissionedAttributesMetadata == null) return;
+        DecommissionedAttributeMetadata decommissionedAttribute = decommissionedAttributesMetadata.decommissionedAttribute("awareness");
+        if(decommissionedAttribute == null) return;
+        for(String decommissionedZone: decommissionedAttribute.decommissionedAttribute().values()){
+            if (node.getAttributes().get(decommissionedAttribute.decommissionedAttribute().key()).equals(decommissionedZone)) {
+                throw new NodeDecommissionedException(
+                    "node is decommissioned"
+                );
+            }
+        }
+    }
+
     public static Collection<BiConsumer<DiscoveryNode, ClusterState>> addBuiltInJoinValidators(
         Collection<BiConsumer<DiscoveryNode, ClusterState>> onJoinValidators
     ) {
@@ -471,6 +487,7 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTaskExecut
         validators.add((node, state) -> {
             ensureNodesCompatibility(node.getVersion(), state.getNodes());
             ensureIndexCompatibility(node.getVersion(), state.getMetadata());
+            ensureNodeNotDecommissioned(node, state.getMetadata());
         });
         validators.addAll(onJoinValidators);
         return Collections.unmodifiableCollection(validators);

--- a/server/src/main/java/org/opensearch/cluster/coordination/NodeDecommissionedException.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/NodeDecommissionedException.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.coordination;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.cluster.decommission.DecommissionService;
+import org.opensearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * This exception is thrown if the node is decommissioned by @{@link DecommissionService}
+ * and this nodes needs to be removed from the cluster
+ *
+ * @opensearch.internal
+ */
+
+public class NodeDecommissionedException extends OpenSearchException {
+
+    public NodeDecommissionedException(String msg, Object... args) {
+        super(msg, args);
+    }
+
+    public NodeDecommissionedException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionService.java
@@ -1,0 +1,220 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.decommission;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.decommission.put.PutDecommissionRequest;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ClusterStateApplier;
+import org.opensearch.cluster.ClusterStateTaskConfig;
+import org.opensearch.cluster.ClusterStateUpdateTask;
+import org.opensearch.cluster.ack.ClusterStateUpdateResponse;
+import org.opensearch.cluster.coordination.NodeRemovalClusterStateTaskExecutor;
+import org.opensearch.cluster.metadata.DecommissionedAttributeMetadata;
+import org.opensearch.cluster.metadata.DecommissionedAttributesMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.routing.allocation.AllocationService;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Priority;
+import org.opensearch.common.component.AbstractLifecycleComponent;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.threadpool.ThreadPool;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DecommissionService extends AbstractLifecycleComponent implements ClusterStateApplier {
+
+    private static final Logger logger = LogManager.getLogger(DecommissionService.class);
+
+    private final ClusterService clusterService;
+    private final NodeRemovalClusterStateTaskExecutor nodeRemovalExecutor;
+    private final ThreadPool threadPool;
+
+    @Inject
+    public DecommissionService(
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        AllocationService allocationService
+    ) {
+        this.clusterService = clusterService;
+        this.threadPool = threadPool;
+        this.nodeRemovalExecutor = new NodeRemovalClusterStateTaskExecutor(allocationService, logger);
+    }
+
+    /**
+     * Registers new decommissioned attribute in the cluster
+     * <p>
+     * This method can be only called on the cluster-manager node. It tries to create a new decommissioned attribute on the master
+     * and if it was successful it adds new decommissioned attribute to cluster metadata.
+     *
+     * @param request  register decommission request
+     * @param listener register decommission listener
+     */
+    public void registerDecommissionAttribute(
+        final PutDecommissionRequest request,
+        final ActionListener<ClusterStateUpdateResponse> listener
+    ) {
+//        assert lifecycle.started() : "Trying to decommission an attribute but service is in state [" + lifecycle.state() + "]";
+
+        final DecommissionedAttributeMetadata newDecommissionedAttributeMetadata = new DecommissionedAttributeMetadata(
+            request.getName(),
+            request.getDecommissionAttribute().key(),
+            request.getDecommissionAttribute().values()
+        );
+
+        // TODO - add validator on decommission attribute - to check if its a valid attribute
+        // validate(request.name)
+
+        final ActionListener<ClusterStateUpdateResponse> registrationListener;
+        // TODO - this listener can be used to verify if the response was acknowledged by all the nodes -
+        //  can be read from the request if the query param had verify
+        // if request.verify() -> perform task
+
+        registrationListener = listener;
+
+        // TODO - Can we do the decommission action here? before we push the new metadata to cluster state
+
+        clusterService.submitStateUpdateTask(
+            // TODO - put request.name instead of zone
+            "put_decommission [" + request.getName() + "]",
+            new ClusterStateUpdateTask(Priority.URGENT) {
+//                @Override
+//                protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+//                    return new ClusterStateUpdateResponse(acknowledged);
+//                }
+
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    //TODO - before updating cluster state ensure attribute is not in use
+                    Metadata metadata = currentState.metadata();
+                    Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
+                    DecommissionedAttributesMetadata decommissionedAttributes = metadata.custom(DecommissionedAttributesMetadata.TYPE);
+                    if (decommissionedAttributes == null) {
+                        // TODO - get attribute details from request
+                        logger.info("decommission request for attribute name [{}] and attribute value [{}]", request.getName(), request.getDecommissionAttribute().toString());
+                        decommissionedAttributes = new DecommissionedAttributesMetadata(
+                            Collections.singletonList(new DecommissionedAttributeMetadata(request.getName(), request.getDecommissionAttribute().key(), request.getDecommissionAttribute().values()))
+                        );
+                    } else {
+                        boolean found = false;
+                        List<DecommissionedAttributeMetadata> decommissionedAttributesMetadata = new ArrayList<>(
+                            decommissionedAttributes.decommissionedAttributes().size() + 1
+                        );
+                        for (DecommissionedAttributeMetadata decommissionedAttributeMetadata : decommissionedAttributes.decommissionedAttributes()) {
+                            if (decommissionedAttributeMetadata.name().equals(newDecommissionedAttributeMetadata.name())) {
+                                if (newDecommissionedAttributeMetadata.equals(decommissionedAttributeMetadata)) {
+                                    // No update needed
+                                    return currentState;
+                                }
+                                found = true;
+                                decommissionedAttributesMetadata.add(newDecommissionedAttributeMetadata);
+                            } else {
+                                decommissionedAttributesMetadata.add(decommissionedAttributeMetadata);
+                            }
+                        }
+                        if (!found) {
+                            // TODO update name based on request
+                            logger.info("put decommissioned attribute [{}]", request.getDecommissionAttribute().toString());
+                            decommissionedAttributesMetadata.add(
+                                new DecommissionedAttributeMetadata(
+                                    request.getName(),
+                                    request.getDecommissionAttribute().key(),
+                                    request.getDecommissionAttribute().values()
+                                )
+                            );
+                        } else {
+                            // TODO - update name based on request
+                            logger.info("update decommission attribute [{}]", request.getDecommissionAttribute().toString());
+                        }
+                        decommissionedAttributes = new DecommissionedAttributesMetadata(decommissionedAttributesMetadata);
+                    }
+                    mdBuilder.putCustom(DecommissionedAttributesMetadata.TYPE, decommissionedAttributes);
+                    return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    logger.warn(() -> new ParameterizedMessage("failed to decommission attribute [{}]", request.getName()), e);
+                    listener.onFailure(e);
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    failDecommissionedNodes(newState);
+                    listener.onResponse(new ClusterStateUpdateResponse(true));
+                }
+//                @Override
+//                public boolean mustAck(DiscoveryNode discoveryNode) {
+//                    // master must acknowledge the metadata change
+//                    return discoveryNode.isMasterNode();
+//                }
+            }
+        );
+    }
+
+    @Override
+    public void applyClusterState(ClusterChangedEvent event) {
+
+    }
+
+    @Override
+    protected void doStart() {
+
+    }
+
+    @Override
+    protected void doStop() {
+
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+
+    }
+
+    //TODO - Similarly we can create a registerRecommissionAttribute to recommission a zone
+//    public void registerRecommissionAttribute(
+//        final ClusterManagementRecommissionRequest request,
+//        final ActionListener<ClusterStateUpdateResponse> listener
+//    )
+
+    public void failDecommissionedNodes(ClusterState updatedState) {
+        DiscoveryNode[] discoveryNodes = updatedState.nodes().getNodes().values().toArray(DiscoveryNode.class);
+        DecommissionedAttributesMetadata decommissionedAttributes = updatedState.metadata().custom(DecommissionedAttributesMetadata.TYPE);
+        DecommissionedAttributeMetadata metadata = decommissionedAttributes.decommissionedAttribute("awareness");
+        assert metadata != null : "No nodes to decommission";
+        DecommissionedAttribute decommissionedAttribute = metadata.decommissionedAttribute();
+        for (DiscoveryNode discoveryNode : discoveryNodes) {
+            for (String zone : decommissionedAttribute.values()) {
+                if (zone.equals(discoveryNode.getAttributes().get(decommissionedAttribute.key()))) {
+                    removeDecommissionedNodes(discoveryNode);
+                }
+            }
+        }
+    }
+
+    private void removeDecommissionedNodes(DiscoveryNode discoveryNode) {
+        clusterService.submitStateUpdateTask(
+            "node-decommissioned",
+            new NodeRemovalClusterStateTaskExecutor.Task(discoveryNode, "node is decommissioned"),
+            ClusterStateTaskConfig.build(Priority.IMMEDIATE),
+            nodeRemovalExecutor,
+            nodeRemovalExecutor
+        );
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/decommission/DecommissionedAttribute.java
+++ b/server/src/main/java/org/opensearch/cluster/decommission/DecommissionedAttribute.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.decommission;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public final class DecommissionedAttribute implements Writeable {
+    private final String key;
+    private final List<String> values;
+
+    public DecommissionedAttribute(DecommissionedAttribute decommissionedAttribute, List<String> values) {
+        this(decommissionedAttribute.key, values);
+    }
+
+    /**
+     * Constructs new decommission attribute key value pair
+     *
+     * @param key    attribute name
+     * @param values attribute values
+     */
+    public DecommissionedAttribute(String key, List<String> values) {
+        this.key = key;
+        this.values = values;
+    }
+
+    /**
+     * Returns attribute key
+     *
+     * @return attribute key
+     */
+    public String key() {
+        return this.key;
+    }
+
+    /**
+     * Returns attribute value
+     *
+     * @return attribute value
+     */
+    public List<String> values() {
+        return this.values;
+    }
+
+    public DecommissionedAttribute(StreamInput in) throws IOException {
+        key = in.readString();
+        values = in.readStringList();
+    }
+
+    /**
+     * Writes decommission attribute key values to stream output
+     *
+     * @param out stream output
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(key);
+        out.writeStringCollection(values);
+    }
+
+    /**
+     * Checks if this instance is equal to the other instance in key other than {@link #values}.
+     *
+     * @param other other decommission attribute key values
+     * @return {@code true} if both instances equal in key fields but the values fields
+     */
+    public boolean equalsIgnoreValues(DecommissionedAttribute other) {
+        return key.equals(other.key);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DecommissionedAttribute that = (DecommissionedAttribute) o;
+
+        if (!key.equals(that.key)) return false;
+        return values.equals(that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, values);
+    }
+
+    @Override
+    public String toString() {
+        return "DecommissionedAttribute{" + key + "}{" + values().toString() + "}";
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/metadata/DecommissionedAttributeMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/DecommissionedAttributeMetadata.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.cluster.decommission.DecommissionedAttribute;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class DecommissionedAttributeMetadata implements Writeable {
+
+    private final String name;
+    private final DecommissionedAttribute decommissionedAttribute;
+
+    public DecommissionedAttributeMetadata(DecommissionedAttributeMetadata metadata, DecommissionedAttribute decommissionedAttribute) {
+        this(metadata.name, decommissionedAttribute);
+    }
+
+    /**
+     * Constructs new decommissioned attribute metadata
+     *
+     * @param name                  attribute name
+     * @param decommissionedAttribute attribute value
+     */
+    public DecommissionedAttributeMetadata(String name, DecommissionedAttribute decommissionedAttribute) {
+        this.name = name;
+        this.decommissionedAttribute = decommissionedAttribute;
+    }
+
+    public DecommissionedAttributeMetadata(String name, String key, List<String> values) {
+        this(name, new DecommissionedAttribute(key, values));
+    }
+
+    /**
+     * Returns attribute name
+     *
+     * @return attribute name
+     */
+    public String name() {
+        return this.name;
+    }
+
+    /**
+     * Returns attribute value
+     *
+     * @return attribute value
+     */
+    public DecommissionedAttribute decommissionedAttribute() {
+        return this.decommissionedAttribute;
+    }
+
+    public DecommissionedAttributeMetadata(StreamInput in) throws IOException {
+        name = in.readString();
+        decommissionedAttribute = new DecommissionedAttribute(in);
+    }
+
+    /**
+     * Writes decommissioned attribute metadata to stream output
+     *
+     * @param out stream output
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        decommissionedAttribute.writeTo(out);
+    }
+
+    /**
+     * Checks if this instance is equal to the other instance in name other than {@link #decommissionedAttribute}.
+     *
+     * @param other other decommissioned attribute metadata
+     * @return {@code true} if both instances equal in all fields but the values fields
+     */
+    public boolean equalsIgnoreValues(DecommissionedAttributeMetadata other) {
+        return name.equals(other.name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DecommissionedAttributeMetadata that = (DecommissionedAttributeMetadata) o;
+
+        if (!name.equals(that.name)) return false;
+        return decommissionedAttribute.equals(that.decommissionedAttribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, decommissionedAttribute);
+    }
+
+    @Override
+    public String toString() {
+        return "DecommissionedAttributeMetadata{" + name + "}{" + decommissionedAttribute().toString() + "}";
+    }
+}

--- a/server/src/main/java/org/opensearch/cluster/metadata/DecommissionedAttributesMetadata.java
+++ b/server/src/main/java/org/opensearch/cluster/metadata/DecommissionedAttributesMetadata.java
@@ -1,0 +1,243 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.metadata;
+
+import org.opensearch.OpenSearchParseException;
+import org.opensearch.Version;
+import org.opensearch.cluster.AbstractNamedDiffable;
+import org.opensearch.cluster.NamedDiff;
+import org.opensearch.cluster.decommission.DecommissionedAttribute;
+import org.opensearch.cluster.metadata.Metadata.Custom;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+
+/**
+ * Contains metadata about decommissioned attributes
+ *
+ * @opensearch.internal
+ */
+public class DecommissionedAttributesMetadata extends AbstractNamedDiffable<Custom> implements Custom {
+
+    public static final String TYPE = "decommissionedAttributes";
+
+    private final List<DecommissionedAttributeMetadata> decommissionedAttributes;
+
+    /**
+     * Constructs new decommissioned attributes metadata
+     *
+     * @param decommissionedAttributes list of decommissionedAttribute
+     */
+    public DecommissionedAttributesMetadata(List<DecommissionedAttributeMetadata> decommissionedAttributes) {
+        this.decommissionedAttributes = Collections.unmodifiableList(decommissionedAttributes);
+    }
+
+    /**
+     * Creates a new instance that has the given attribute name moved to the given {@code values}.
+     *
+     * @param name                    attribute name
+     * @param decommissionedAttribute new decommissioned attribute metadata
+     * @return new instance with updated attribute values
+     */
+    public DecommissionedAttributesMetadata withUpdatedAttributeValues(
+        String name,
+        DecommissionedAttribute decommissionedAttribute
+    ) {
+        int indexOfAttribute = -1;
+        for (int i = 0; i < decommissionedAttributes.size(); i++) {
+            if (decommissionedAttributes.get(i).name().equals(name)) {
+                indexOfAttribute = i;
+                break;
+            }
+        }
+        if (indexOfAttribute < 0) {
+            throw new IllegalArgumentException("Unknown attribute [" + name + "]");
+        }
+        final List<DecommissionedAttributeMetadata> updatedDecommissionedAttributes = new ArrayList<>(decommissionedAttributes);
+        updatedDecommissionedAttributes.set(
+            indexOfAttribute,
+            new DecommissionedAttributeMetadata(decommissionedAttributes.get(indexOfAttribute), decommissionedAttribute));
+        return new DecommissionedAttributesMetadata(updatedDecommissionedAttributes);
+    }
+
+    /**
+     * Returns list of currently decommissioned attributes
+     *
+     * @return list of decommissioned attributes
+     */
+    public List<DecommissionedAttributeMetadata> decommissionedAttributes() {
+        return this.decommissionedAttributes;
+    }
+
+    /**
+     * Returns a decommissioned attribute with a given name or null if such attribute doesn't exist
+     *
+     * @param name name of decommissioned attribute
+     * @return decommissioned attribute metadata
+     */
+    public DecommissionedAttributeMetadata decommissionedAttribute(String name) {
+        for (DecommissionedAttributeMetadata decommissionedAttribute : decommissionedAttributes) {
+            if (name.equals(decommissionedAttribute.name())) {
+                return decommissionedAttribute;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DecommissionedAttributesMetadata that = (DecommissionedAttributesMetadata) o;
+
+        return decommissionedAttributes.equals(that.decommissionedAttributes);
+    }
+
+    /**
+     * Checks if this instance and the given instance share the same decommissioned attributes by checking that this instances' attributes and the
+     * attributes in {@code other} are equal or only differ in their attribute values of {@link DecommissionedAttributeMetadata#decommissionedAttribute()}.
+     *
+     * @param other other decommissioned attributes metadata
+     * @return {@code true} iff both instances contain the same decommissioned attributes apart from differences in attribute values
+     */
+    public boolean equalsIgnoreValues(@Nullable DecommissionedAttributesMetadata other) {
+        if (other == null) {
+            return false;
+        }
+        if (other.decommissionedAttributes.size() != decommissionedAttributes.size()) {
+            return false;
+        }
+        for (int i = 0; i < decommissionedAttributes.size(); i++) {
+            if (decommissionedAttributes.get(i).equalsIgnoreValues(other.decommissionedAttributes.get(i)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return decommissionedAttributes.hashCode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.CURRENT.minimumCompatibilityVersion();
+    }
+
+    public DecommissionedAttributesMetadata(StreamInput in) throws IOException {
+        this.decommissionedAttributes = in.readList(DecommissionedAttributeMetadata::new);
+    }
+
+    public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {
+        return readDiffFrom(Custom.class, TYPE, in);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeList(decommissionedAttributes);
+    }
+
+    public static DecommissionedAttributesMetadata fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token token;
+        List<DecommissionedAttributeMetadata> decommissionedAttributes = new ArrayList<>();
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                String name = parser.currentName();
+                if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+                    throw new OpenSearchParseException("failed to parse decommission attribute [{}], expected object", name);
+                }
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        String currentFieldName = parser.currentName();
+                        List<String> values = new ArrayList<>();
+                        token = parser.nextToken();
+                        if (token == XContentParser.Token.VALUE_STRING) {
+                            values.add(parser.text());
+                        } else if (token == XContentParser.Token.START_ARRAY) {
+                            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                                if (token == XContentParser.Token.VALUE_STRING) {
+                                    values.add(parser.text());
+                                } else {
+                                    parser.skipChildren();
+                                }
+                            }
+                        } else throw new OpenSearchParseException("failed to parse attribute [{}], unknown type", name);
+                        decommissionedAttributes.add(new DecommissionedAttributeMetadata(name, currentFieldName, values));
+                    } else {
+                        throw new OpenSearchParseException("failed to parse attribute [{}]", name);
+                    }
+                }
+            }
+        }
+        return new DecommissionedAttributesMetadata(decommissionedAttributes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        for (DecommissionedAttributeMetadata decommissionedAttribute : decommissionedAttributes) {
+            toXContent(decommissionedAttribute, builder, params);
+        }
+        return builder;
+    }
+
+    @Override
+    public EnumSet<Metadata.XContentContext> context() {
+        return Metadata.API_AND_GATEWAY;
+    }
+
+    /**
+     * Serializes information about a single decommissioned attribute
+     *
+     * @param decommissionedAttribute decommissioned attribute metadata
+     * @param builder                 XContent builder
+     * @param params                  serialization parameters
+     */
+    public static void toXContent(DecommissionedAttributeMetadata decommissionedAttribute, XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject(decommissionedAttribute.name());
+        builder.startArray(decommissionedAttribute.decommissionedAttribute().key());
+        for (String value : decommissionedAttribute.decommissionedAttribute().values()) {
+            builder.value(value);
+        }
+        builder.endArray();
+        builder.endObject();
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(this);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPutDecommissionAction.java
+++ b/server/src/main/java/org/opensearch/rest/action/admin/cluster/RestPutDecommissionAction.java
@@ -1,0 +1,129 @@
+/*
+
+ * SPDX-License-Identifier: Apache-2.0
+
+ *
+
+ * The OpenSearch Contributors require contributions made to
+
+ * this file be licensed under the Apache-2.0 license or a
+
+ * compatible open source license.
+
+ */
+
+
+
+
+package org.opensearch.rest.action.admin.cluster;
+
+
+
+
+import org.apache.logging.log4j.LogManager;
+
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.admin.cluster.decommission.put.PutDecommissionRequest;
+
+import org.opensearch.client.Requests;
+
+import org.opensearch.client.node.NodeClient;
+
+import org.opensearch.rest.BaseRestHandler;
+
+import org.opensearch.rest.RestRequest;
+
+import org.opensearch.rest.action.RestToXContentListener;
+
+
+
+
+import java.io.IOException;
+
+import java.util.List;
+
+
+
+
+import static java.util.Collections.singletonList;
+
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
+
+
+
+/**
+
+ * Transport action to decommission nodes
+
+ *
+
+ * @opensearch.api
+
+ */
+
+public class RestPutDecommissionAction extends BaseRestHandler {
+
+
+
+
+    // TODO - Use debug logs
+
+    private static final Logger logger = LogManager.getLogger(RestPutDecommissionAction.class);
+
+
+
+
+    @Override
+
+    public List<Route> routes() {
+
+        return singletonList(new Route(PUT, "_cluster/management/decommission"));
+
+    }
+
+
+
+
+    @Override
+
+    public String getName() {
+
+        return "put_decommission_action";
+
+    }
+
+
+
+
+    @Override
+
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+
+        PutDecommissionRequest putDecommissionRequest = createRequest(request);
+
+        return channel -> client.admin()
+
+            .cluster()
+
+            .putDecommission(putDecommissionRequest, new RestToXContentListener<>(channel));
+
+    }
+
+
+
+
+    public static PutDecommissionRequest createRequest(RestRequest request) throws IOException {
+
+        // TODO - add params
+
+        PutDecommissionRequest putDecommissionRequest = Requests.putDecommissionRequest();
+
+        request.applyContentParser(p -> putDecommissionRequest.source(p.mapOrdered()));
+
+        return putDecommissionRequest;
+
+    }
+
+}


### PR DESCRIPTION
### Description
Changes for Graceful Node decommission.
This PR is on top of Node decommission PR. And has changes for handling graceful decommission.
When request for node decommission is received we will check the HTTP stats for the nodes being decommissioned. If the decommissioned nodes have active http request open we will wait for these active requests to be completed.

### The real change is in. 
[server/src/main/java/org/opensearch/action/admin/cluster/decommission/put/TransportPutDecommissionAction.java](https://github.com/pranikum/OpenSearch/pull/1/files#diff-849967a77ed9b839e5b6de9ef959bf8c01dbb3dcb139813dab7c093e8ac0b0c2)

Rest are taken from Dependent PR

## Depends On: https://github.com/opensearch-project/OpenSearch/pull/3920

### Issues Resolved
3956

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
